### PR TITLE
Add ability to exclude clients by MAC address

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ Standalone Unifi Controller
       "unifios": false
     },
     "interval": 180,  // polling interval in case websocket connection is lost
-    "accessory": "UniFi Guest Occupancy Sensor"
+    "accessory": "UniFi Guest Occupancy Sensor",
+    "exclude": [
+      "01:23:45:67:89:ab"
+    ]
   }
 ]
 ```
@@ -36,7 +39,10 @@ For UnifiOS based device (UDM, KC, etc.), use port 443 (default) and set unifios
       "unifios": true
     },
     "interval": 180,  // polling interval in case websocket connection is lost
-    "accessory": "UniFi Guest Occupancy Sensor"
+    "accessory": "UniFi Guest Occupancy Sensor",
+    "exclude": [
+      "01:23:45:67:89:ab"
+    ]
   }
 ]
 ```

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ class OccupancySensor {
     this.occupancyService = new Service.OccupancySensor(this.name);
     this.guestNetworks = config.guestNetworks || [];
     this.interval = config.interval || 180;
+    this.exclude = config.exclude || [];
 
     this.controller=url.parse(config.unifi.controller);
 
@@ -48,7 +49,7 @@ class OccupancySensor {
   }
 
   checkOccupancy() {
-    const guestIsPresent = (device) => device.is_guest === true;
+    const guestIsPresent = (device) => device.is_guest === true && !this.exclude.includes(device.mac);
     this.unifi.get('stat/sta').then((res) => {
       if (res.data.some(guestIsPresent)) {
         this.log("Guests are present");

--- a/sample-config-unifios.json
+++ b/sample-config-unifios.json
@@ -10,6 +10,9 @@
       "unifios": true
     },
     "interval": 180,
-    "accessory": "UniFi Guest Occupancy Sensor"
+    "accessory": "UniFi Guest Occupancy Sensor",
+    "exclude": [
+      "01:23:45:67:89:ab"
+    ]
   }
 ]

--- a/sample-config.json
+++ b/sample-config.json
@@ -10,6 +10,9 @@
       "unifios": false
     },
     "interval": 180,
-    "accessory": "UniFi Guest Occupancy Sensor"
+    "accessory": "UniFi Guest Occupancy Sensor",
+    "exclude": [
+      "01:23:45:67:89:ab"
+    ]
   }
 ]


### PR DESCRIPTION
I have a few clients on my guest network that are always home that I wouldn't want to count as occupying.  This change adds an "exclude" array to the config file and that array is checked along with is_guest.  I don't have the best dev environment setup so I still need to finish testing to make sure this is working properly, but wanted to at least push what I have so far.